### PR TITLE
slim-bullseye with current Python 3.9.x and GOB-Core.

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,15 +1,16 @@
 # syntax=docker/dockerfile:1
-FROM amsterdam/gob_wheelhouse:3.9-bullseye as wheelhouse
+FROM amsterdam/gob_wheelhouse:3.9-slim-bullseye as wheelhouse
 MAINTAINER datapunt@amsterdam.nl
 
 
 # Application stage.
-FROM amsterdam/gob_baseimage:3.9-bullseye as application
+FROM amsterdam/gob_baseimage:3.9-slim-bullseye as application
 MAINTAINER datapunt@amsterdam.nl
 # GOB base image: SQL Server driver.
 
 # libxml
-RUN apt-get install -y libxml2-dev libxmlsec1-dev
+RUN apt-get update && apt-get install -y libxml2-dev libxmlsec1-dev
+RUN rm -rf /var/lib/apt/lists/*
 
 # Fill the wheelhouse.
 COPY --from=wheelhouse /opt/wheelhouse /opt/wheelhouse

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,7 +1,7 @@
 Flask==2.3.2
 Flask-Cors==3.0.10
 freezegun~=1.2.2
-git+https://github.com/Amsterdam/GOB-Core.git@v2.22.0
+git+https://github.com/Amsterdam/GOB-Core.git@v2.23.0
 xmlsec~=1.3.13
 zeep~=4.2.1
 alembic~=1.11.3


### PR DESCRIPTION
slim-bullseye met Python 3.9.18 en vanwege `gobcore.model.amschema.repo.AMSchemaError: Table maatschappelijkeactiviteiten/2.7.0 does not exist in dataset hr`